### PR TITLE
multilan site - good practice with prefs

### DIFF
--- a/MentionsNotification.php
+++ b/MentionsNotification.php
@@ -395,7 +395,7 @@ class MentionsNotification extends Mentions
 	 */
 	public function emailSubject()
 	{
-		$subjectLine = trim($this->prefs['email_subject_line']);
+		$subjectLine = trim($this->prefs['email_subject_line'][e_LANGUAGE]);
 		if (null !== $subjectLine && $subjectLine !== '') {
 			return str_replace('{MENTIONER}', $this->mentioner, $subjectLine);
 		}

--- a/admin_config.php
+++ b/admin_config.php
@@ -147,6 +147,7 @@ class mentions_ui extends e_admin_ui
 			'data'  => 'str',
 			'size'  => 'xxlarge',
 			'help'  => LAN_MENTIONS_PREF_LBL_HINT_EMAIL_SUBJECT,
+			'multilan'=>true,
 		],
 
 	];


### PR DESCRIPTION
If you have any prefs that can be consider as "multilan", its good idea from beginning do it as multilan field.

This is discussion about it:
https://github.com/e107inc/e107/issues/2591

If you add multilan option later, it will display array() and user could be confused.